### PR TITLE
Crate assets support

### DIFF
--- a/Bundle/PackageEntry.cs
+++ b/Bundle/PackageEntry.cs
@@ -25,17 +25,6 @@
         /// </summary>
         public int Length { get; set; }
 
-		public string FileSize{
-			get {
-				long bytesNo = this.Length;
-
-				if (bytesNo < 1024)
-					return bytesNo.ToString () + " B";
-				else
-					return string.Format ("{0:n0}", bytesNo / 1024) + " KB";
-			}
-		}
-
 		public PackageHeader Parent { get; set; }
 
 		public Idstring PackageName {get { return this.Parent?.Name; }}

--- a/Crate/CrateFile.cs
+++ b/Crate/CrateFile.cs
@@ -1,0 +1,206 @@
+namespace DieselEngineFormats.Crate
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using DieselEngineFormats.Bundle;
+    using DieselEngineFormats.Utils;
+
+    /// <summary>
+    ///     A single entry in a .crate file's table of contents.
+    /// </summary>
+    public class CrateFileEntry
+    {
+        /// <summary>
+        ///     The asset's type/extension (e.g. "texture", "unit", "lua").
+        /// </summary>
+        public Idstring Extension { get; set; }
+
+        /// <summary>
+        ///     The asset's full path.
+        /// </summary>
+        public Idstring Path { get; set; }
+
+        /// <summary>
+        ///     Absolute byte offset of this entry's data within the .crate file.
+        /// </summary>
+        public ulong Offset { get; set; }
+
+        /// <summary>
+        ///     Size of the entry after decompression.
+        /// </summary>
+        public ulong RawSize { get; set; }
+
+        /// <summary>
+        ///     Compressed size on disk. Zero means stored uncompressed (movie/
+        ///     stream/animation data)
+        /// </summary>
+        public ulong StoredSize { get; set; }
+
+        /// <summary>
+        ///     A single bitflag identifying a language/platform variant (e.g.
+        ///     "english", "d3d11") of the same path -- the same (Extension,
+        ///     Path) pair can appear as multiple TOC entries, one per variant.
+        ///     Resolve via crates.properties / CratePropertyList (flag ->
+        ///     name), not HashIndex.
+        /// </summary>
+        public ulong VariantFlag { get; set; }
+
+        public CrateFile Parent { get; set; }
+
+        public CrateFileEntry() { }
+
+        public CrateFileEntry(BinaryReader br)
+        {
+            ReadEntry(br);
+        }
+
+        public void ReadEntry(BinaryReader br)
+        {
+            Extension = HashIndex.Get(br.ReadUInt64());
+            Path = HashIndex.Get(br.ReadUInt64());
+            Offset = br.ReadUInt64();
+            RawSize = br.ReadUInt64();
+            StoredSize = br.ReadUInt64();
+            VariantFlag = br.ReadUInt64();
+        }
+
+        public void WriteEntry(BinaryWriter bw)
+        {
+            bw.Write(Extension.Hashed);
+            bw.Write(Path.Hashed);
+            bw.Write(Offset);
+            bw.Write(RawSize);
+            bw.Write(StoredSize);
+            bw.Write(VariantFlag);
+        }
+
+        public override string ToString()
+        {
+            string variant = VariantFlag != 0 ? $" variant={VariantFlag:x}" : "";
+            return $"{Path}.{Extension} (offset: {Offset}, raw: {RawSize}, stored: {StoredSize}{variant})";
+        }
+    }
+
+    /// <summary>
+    ///     Reader for the self-contained .crate package format. A .crate
+    ///     carries its own table of contents and asset data in one file.
+    ///
+    ///     Layout: header (16 bytes: magic "YAOI", format, entry count,
+    ///     reserved), then `count` * 48-byte CrateFileEntry records, then the
+    ///     data region starting at the fixed offset DataRegionStart.
+    /// </summary>
+    public class CrateFile : DieselFormat
+    {
+        /// <summary>ASCII "YAOI", read as a little-endian uint32.</summary>
+        public const uint Magic = 0x494F4159;
+
+        /// <summary>Every .crate reserves this many bytes up front for its TOC.</summary>
+        public const ulong DataRegionStart = 1_000_000;
+
+        /// <summary>Observed constant (65536) across every sampled .crate file.</summary>
+        public uint Format { get; set; }
+
+        public List<CrateFileEntry> Entries { get; } = new List<CrateFileEntry>();
+
+        /// <summary>
+        ///     Path this CrateFile was loaded from, if constructed via a file path.
+        ///     Used to reopen the file on demand in <see cref="ReadEntry(CrateFileEntry)"/>.
+        /// </summary>
+        public string FilePath { get; private set; }
+
+        public CrateFile() { }
+
+        public CrateFile(string filePath) : base(filePath)
+        {
+            FilePath = filePath;
+        }
+
+        public CrateFile(Stream fileStream) : base(fileStream) { }
+
+        public override void ReadFile(BinaryReader br)
+        {
+            uint magic = br.ReadUInt32();
+            if (magic != Magic)
+                throw new InvalidDataException($"Not a .crate file (expected magic 0x{Magic:X8}, got 0x{magic:X8})");
+
+            Format = br.ReadUInt32();
+            uint count = br.ReadUInt32();
+            br.ReadUInt32(); // reserved
+
+            Entries.Clear();
+            Entries.Capacity = (int)count;
+            for (int i = 0; i < count; i++)
+                Entries.Add(new CrateFileEntry(br) { Parent = this });
+        }
+
+        /// <summary>
+        ///     Reads and decompresses an entry's bytes from an already-open
+        ///     stream, which is not owned/closed by this method.
+        /// </summary>
+        public byte[] ReadEntry(CrateFileEntry entry, Stream stream)
+        {
+            if (entry.RawSize == 0)
+                return Array.Empty<byte>();
+
+            if (entry.StoredSize == 0)
+                return ReadRaw(stream, entry.Offset, entry.RawSize, entry);
+
+            stream.Position = (long)entry.Offset;
+            byte[] compressed = new byte[entry.StoredSize];
+            int readTotal = 0;
+            while (readTotal < compressed.Length)
+            {
+                int read = stream.Read(compressed, readTotal, compressed.Length - readTotal);
+                if (read <= 0)
+                    throw new EndOfStreamException($"Unexpected end of stream reading entry {entry} at offset {entry.Offset}");
+                readTotal += read;
+            }
+
+            using var input = new MemoryStream(compressed);
+            using var output = new MemoryStream((int)entry.RawSize);
+            General.ZLibDecompress(input, output);
+
+            byte[] result = output.ToArray();
+            if ((ulong)result.LongLength != entry.RawSize)
+                throw new InvalidDataException(
+                    $"Decompressed size {result.LongLength} does not match declared raw size {entry.RawSize} for entry {entry}");
+
+            return result;
+        }
+
+        private static byte[] ReadRaw(Stream stream, ulong offset, ulong length, CrateFileEntry entry)
+        {
+            stream.Position = (long)offset;
+            byte[] data = new byte[length];
+            int readTotal = 0;
+            while (readTotal < data.Length)
+            {
+                int read = stream.Read(data, readTotal, data.Length - readTotal);
+                if (read <= 0)
+                    throw new EndOfStreamException($"Unexpected end of stream reading entry {entry} at offset {offset}");
+                readTotal += read;
+            }
+            return data;
+        }
+
+        /// <summary>
+        ///     Reads and decompresses an entry by reopening the file this
+        ///     CrateFile was constructed from.
+        /// </summary>
+        public byte[] ReadEntry(CrateFileEntry entry)
+        {
+            if (FilePath == null)
+                throw new InvalidOperationException(
+                    "CrateFile has no associated file path (constructed from a stream) -- use ReadEntry(entry, stream) instead.");
+
+            using var fs = new FileStream(FilePath, FileMode.Open, FileAccess.Read);
+            return ReadEntry(entry, fs);
+        }
+
+        public CrateFileEntry EntryFromPathHash(ulong pathHash)
+        {
+            return Entries.Find(e => e.Path.Hashed == pathHash);
+        }
+    }
+}

--- a/Crate/CrateManifest.cs
+++ b/Crate/CrateManifest.cs
@@ -1,0 +1,187 @@
+namespace DieselEngineFormats.Crate
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Text;
+    using DieselEngineFormats.Bundle;
+
+    /// <summary>
+    ///     One asset record inside a CrateManifest block. Tracks existence/type/
+    ///     build-time only -- offset/size lives in the .crate file's own TOC.
+    /// </summary>
+    public class CrateManifestEntry
+    {
+        public Idstring Extension { get; set; }
+
+        public Idstring Path { get; set; }
+
+        /// <summary>Windows FILETIME (100ns ticks since 1601-01-01) the source asset was built.</summary>
+        public ulong Timestamp { get; set; }
+
+        public DateTime? BuildTime => Timestamp == 0
+            ? (DateTime?)null
+            : DateTime.FromFileTimeUtc((long)Timestamp);
+
+        /// <summary>
+        ///     Same variant bitflag as CrateFileEntry.VariantFlag, but unreliable
+        ///     here -- the manifest doesn't list every variant. Use the .crate
+        ///     TOCs as the source of truth for variants.
+        /// </summary>
+        public ulong VariantFlag { get; set; }
+
+        public CrateManifestEntry(BinaryReader br)
+        {
+            Extension = HashIndex.Get(br.ReadUInt64());
+            Path = HashIndex.Get(br.ReadUInt64());
+            Timestamp = br.ReadUInt64();
+            VariantFlag = br.ReadUInt64();
+        }
+
+        public override string ToString() => $"{Path}.{Extension}";
+    }
+
+    /// <summary>
+    ///     All the asset records belonging to one .crate file, as listed in a
+    ///     CrateManifest.
+    /// </summary>
+    public class CrateManifestBlock
+    {
+        /// <summary>Crate file this block describes, e.g. "assets_00_0" (-> assets_00_0.crate).</summary>
+        public string CrateName { get; set; }
+
+        public List<CrateManifestEntry> Entries { get; } = new List<CrateManifestEntry>();
+    }
+
+    /// <summary>
+    ///     A name to bitflag mapping (language/platform variants, e.g. "italian",
+    ///     "d3d10"), found standalone in crates.properties and as a trailer in
+    ///     crates.shipping_manifest.
+    /// </summary>
+    public class CratePropertyEntry
+    {
+        public Idstring Name { get; set; }
+
+        /// <summary>Unique power-of-two flag id for this variant.</summary>
+        public uint Flag { get; set; }
+    }
+
+    /// <summary>
+    ///     Reader for crates.shipping_manifest: a global index of which assets
+    ///     exist and what type they are, across every .crate file. No offsets/
+    ///     sizes -- open the individual CrateFile to extract data.
+    ///
+    ///     Layout: global header (12 bytes: version, flags, reserved), then
+    ///     repeated blocks (crate name, entry count, that many 32-byte
+    ///     CrateManifestEntry records) until an empty crate name, then a
+    ///     trailer holding the same property/bitflag table as crates.properties
+    ///     (minus the "YURI" magic and padding).
+    /// </summary>
+    public class CrateManifest : DieselFormat
+    {
+        public uint Version { get; set; }
+
+        public uint Flags { get; set; }
+
+        public List<CrateManifestBlock> Blocks { get; } = new List<CrateManifestBlock>();
+
+        public List<CratePropertyEntry> Properties { get; } = new List<CratePropertyEntry>();
+
+        public CrateManifest() { }
+        public CrateManifest(string filePath) : base(filePath) { }
+        public CrateManifest(Stream fileStream) : base(fileStream) { }
+
+        public override void ReadFile(BinaryReader br)
+        {
+            Version = br.ReadUInt32();
+            Flags = br.ReadUInt32();
+            br.ReadUInt32(); // reserved
+
+            Blocks.Clear();
+            while (true)
+            {
+                long blockStart = br.BaseStream.Position;
+                string name = ReadCString(br);
+
+                if (name.Length == 0)
+                {
+                    // Empty name means this is the trailer's 16 zero-byte prefix, not a block.
+                    br.BaseStream.Position = blockStart + 16;
+                    ReadPropertyTrailer(br);
+                    break;
+                }
+
+                ulong count = br.ReadUInt64();
+                var block = new CrateManifestBlock { CrateName = name };
+                block.Entries.Capacity = (int)count;
+                for (ulong i = 0; i < count; i++)
+                    block.Entries.Add(new CrateManifestEntry(br));
+
+                Blocks.Add(block);
+            }
+        }
+
+        private void ReadPropertyTrailer(BinaryReader br)
+        {
+            ulong count = br.ReadUInt64();
+            Properties.Clear();
+            Properties.Capacity = (int)count;
+            for (ulong i = 0; i < count; i++)
+            {
+                Properties.Add(new CratePropertyEntry
+                {
+                    Name = HashIndex.Get(br.ReadUInt64()),
+                    Flag = br.ReadUInt32(),
+                });
+            }
+        }
+
+        private static string ReadCString(BinaryReader br)
+        {
+            var sb = new StringBuilder();
+            byte b;
+            while ((b = br.ReadByte()) != 0)
+                sb.Append((char)b);
+            return sb.ToString();
+        }
+    }
+
+    /// <summary>
+    ///     Reader for the standalone crates.properties file: a "YURI"-magic
+    ///     name-to-bitflag table, same data as CrateManifest's trailer but with
+    ///     16-byte padded records instead of 12-byte packed ones.
+    /// </summary>
+    public class CratePropertyList : DieselFormat
+    {
+        public const uint Magic = 0x49525559; // ASCII "YURI" as little-endian uint32
+
+        public List<CratePropertyEntry> Properties { get; } = new List<CratePropertyEntry>();
+
+        public CratePropertyList() { }
+        public CratePropertyList(string filePath) : base(filePath) { }
+        public CratePropertyList(Stream fileStream) : base(fileStream) { }
+
+        public override void ReadFile(BinaryReader br)
+        {
+            uint magic = br.ReadUInt32();
+            if (magic != Magic)
+                throw new InvalidDataException($"Not a crates.properties file (expected magic 0x{Magic:X8}, got 0x{magic:X8})");
+
+            uint count = br.ReadUInt32();
+            br.ReadUInt32(); // reserved
+
+            Properties.Clear();
+            Properties.Capacity = (int)count;
+            for (int i = 0; i < count; i++)
+            {
+                var entry = new CratePropertyEntry
+                {
+                    Name = HashIndex.Get(br.ReadUInt64()),
+                    Flag = br.ReadUInt32(),
+                };
+                br.ReadUInt32(); // reserved
+                Properties.Add(entry);
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ I may do some bits here and there in the future. Feel free to fork this repo or 
 | bundle | x | x |
 | script files* | x | x |
 | bnk | x | x |
+| crate | x | |
+| crates.shipping_manifest | x | |
+| crates.properties | x | |
 
 Bundle/blb/Script file support should work for PD:TH/PD2/PD2 Linux files
 

--- a/ZLib/ZLibHeader.cs
+++ b/ZLib/ZLibHeader.cs
@@ -169,7 +169,8 @@ namespace DieselEngineFormats.ZLib
             result.FDict = Convert.ToBoolean(Convert.ToByte((pFlag & 0x20) >> 5));
             result.FLevel = (FLevel)Convert.ToByte((pFlag & 0xC0) >> 6);
 
-            result.IsSupportedZLibStream = (result.CompressionMethod == 8) && (result.CompressionInfo == 7) && (((pCMF * 256 + pFlag) % 31 == 0)) && (result.FDict == false);
+            // CINFO may be 0-7 per RFC 1950 (window size = 2^(CINFO+8)); only >7 is invalid.
+            result.IsSupportedZLibStream = (result.CompressionMethod == 8) && (result.CompressionInfo <= 7) && (((pCMF * 256 + pFlag) % 31 == 0)) && (result.FDict == false);
 
             return result;
         }


### PR DESCRIPTION
Added support for parsing the new crate files in Diesel 3.0.

FileSize helper was removed as it didn't seem particularly appropriate here (and only went up to KBs anyway)

Fixed valid Zlib streams being rejected on the Crate format