### PR TITLE
Tighten up crate shipping_manifest parsing

### DIFF
--- a/Crate/CrateFile.cs
+++ b/Crate/CrateFile.cs
@@ -44,7 +44,7 @@ namespace DieselEngineFormats.Crate
         ///     Resolve via crates.properties / CratePropertyList (flag ->
         ///     name), not HashIndex.
         /// </summary>
-        public ulong VariantFlag { get; set; }
+        public uint VariantFlag { get; set; }
 
         public CrateFile Parent { get; set; }
 
@@ -62,7 +62,8 @@ namespace DieselEngineFormats.Crate
             Offset = br.ReadUInt64();
             RawSize = br.ReadUInt64();
             StoredSize = br.ReadUInt64();
-            VariantFlag = br.ReadUInt64();
+            VariantFlag = br.ReadUInt32();
+            br.ReadUInt32(); // likely padding
         }
 
         public void WriteEntry(BinaryWriter bw)
@@ -73,6 +74,7 @@ namespace DieselEngineFormats.Crate
             bw.Write(RawSize);
             bw.Write(StoredSize);
             bw.Write(VariantFlag);
+            bw.Write(0u); // likely padding
         }
 
         public override string ToString()
@@ -125,12 +127,11 @@ namespace DieselEngineFormats.Crate
                 throw new InvalidDataException($"Not a .crate file (expected magic 0x{Magic:X8}, got 0x{magic:X8})");
 
             Format = br.ReadUInt32();
-            uint count = br.ReadUInt32();
-            br.ReadUInt32(); // reserved
+            ulong count = br.ReadUInt64();
 
             Entries.Clear();
             Entries.Capacity = (int)count;
-            for (int i = 0; i < count; i++)
+            for (ulong i = 0; i < count; i++)
                 Entries.Add(new CrateFileEntry(br) { Parent = this });
         }
 

--- a/Crate/CrateFile.cs
+++ b/Crate/CrateFile.cs
@@ -145,33 +145,35 @@ namespace DieselEngineFormats.Crate
                 return Array.Empty<byte>();
 
             if (entry.StoredSize == 0)
-                return ReadRaw(stream, entry.Offset, entry.RawSize, entry);
+                return ReadExact(stream, entry.Offset, entry.RawSize, entry);
 
-            stream.Position = (long)entry.Offset;
-            byte[] compressed = new byte[entry.StoredSize];
-            int readTotal = 0;
-            while (readTotal < compressed.Length)
-            {
-                int read = stream.Read(compressed, readTotal, compressed.Length - readTotal);
-                if (read <= 0)
-                    throw new EndOfStreamException($"Unexpected end of stream reading entry {entry} at offset {entry.Offset}");
-                readTotal += read;
-            }
+            byte[] compressed = ReadExact(stream, entry.Offset, entry.StoredSize, entry);
 
             using var input = new MemoryStream(compressed);
             using var output = new MemoryStream((int)entry.RawSize);
             General.ZLibDecompress(input, output);
 
-            byte[] result = output.ToArray();
-            if ((ulong)result.LongLength != entry.RawSize)
+            if ((ulong)output.Length != entry.RawSize)
                 throw new InvalidDataException(
-                    $"Decompressed size {result.LongLength} does not match declared raw size {entry.RawSize} for entry {entry}");
+                    $"Decompressed size {output.Length} does not match declared raw size {entry.RawSize} for entry {entry}");
 
-            return result;
+            // GetBuffer avoids a copy: output never grew past its RawSize capacity
+            // (guaranteed by the length check above), so the backing array is
+            // exactly RawSize bytes.
+            return output.GetBuffer();
         }
 
-        private static byte[] ReadRaw(Stream stream, ulong offset, ulong length, CrateFileEntry entry)
+        /// <summary>
+        ///     Seeks to <paramref name="offset"/> and reads exactly
+        ///     <paramref name="length"/> bytes, validating the range against the
+        ///     stream before allocating
+        /// </summary>
+        private static byte[] ReadExact(Stream stream, ulong offset, ulong length, CrateFileEntry entry)
         {
+            if (offset + length > (ulong)stream.Length)
+                throw new InvalidDataException(
+                    $"Entry {entry} at offset {offset} with length {length} extends past end of stream ({stream.Length})");
+
             stream.Position = (long)offset;
             byte[] data = new byte[length];
             int readTotal = 0;

--- a/Crate/CrateFile.cs
+++ b/Crate/CrateFile.cs
@@ -88,8 +88,8 @@ namespace DieselEngineFormats.Crate
     ///     Reader for the self-contained .crate package format. A .crate
     ///     carries its own table of contents and asset data in one file.
     ///
-    ///     Layout: header (16 bytes: magic "YAOI", format, entry count,
-    ///     reserved), then `count` * 48-byte CrateFileEntry records, then the
+    ///     Layout: header (16 bytes: magic "YAOI", format, 64-bit entry
+    ///     count), then `count` * 48-byte CrateFileEntry records, then the
     ///     data region starting at the fixed offset DataRegionStart.
     /// </summary>
     public class CrateFile : DieselFormat

--- a/Crate/CrateManifest.cs
+++ b/Crate/CrateManifest.cs
@@ -24,19 +24,16 @@ namespace DieselEngineFormats.Crate
             : DateTime.FromFileTimeUtc((long)Timestamp);
 
         /// <summary>
-        ///     Same variant bitflag as CrateFileEntry.VariantFlag, but unreliable
-        ///     here -- the manifest doesn't list every variant. Use the .crate
-        ///     TOCs as the source of truth for variants.
+        ///     True if this asset has been overridden by a patch crate.
         /// </summary>
-        public uint VariantFlag { get; set; }
+        public bool IsPatchOverride { get; set; }
 
         public CrateManifestEntry(BinaryReader br)
         {
             Extension = HashIndex.Get(br.ReadUInt64());
             Path = HashIndex.Get(br.ReadUInt64());
             Timestamp = br.ReadUInt64();
-            VariantFlag = br.ReadUInt32();
-            br.ReadUInt32(); // likely padding
+            IsPatchOverride = br.ReadUInt64() != 0; // bool in the low byte, rest is padding
         }
 
         public override string ToString() => $"{Path}.{Extension}";

--- a/Crate/CrateManifest.cs
+++ b/Crate/CrateManifest.cs
@@ -71,17 +71,18 @@ namespace DieselEngineFormats.Crate
     ///     exist and what type they are, across every .crate file. No offsets/
     ///     sizes -- open the individual CrateFile to extract data.
     ///
-    ///     Layout: global header (12 bytes: version, flags, reserved), then
-    ///     repeated blocks (crate name, entry count, that many 32-byte
-    ///     CrateManifestEntry records) until an empty crate name, then a
-    ///     trailer holding the same property/bitflag table as crates.properties
-    ///     (minus the "YURI" magic and padding).
+    ///     Layout: global header (12 bytes: version, block count, reserved),
+    ///     then exactly BlockCount blocks (crate name, entry count, that many
+    ///     32-byte CrateManifestEntry records), then a trailer: a variable-
+    ///     length patch/source list followed by the same property/bitflag table
+    ///     as crates.properties (minus the "YURI" magic and padding).
     /// </summary>
     public class CrateManifest : DieselFormat
     {
         public uint Version { get; set; }
 
-        public uint Flags { get; set; }
+        /// <summary>Number of blocks that follow the header.</summary>
+        public uint BlockCount { get; set; }
 
         public List<CrateManifestBlock> Blocks { get; } = new List<CrateManifestBlock>();
 
@@ -94,23 +95,14 @@ namespace DieselEngineFormats.Crate
         public override void ReadFile(BinaryReader br)
         {
             Version = br.ReadUInt32();
-            Flags = br.ReadUInt32();
+            BlockCount = br.ReadUInt32();
             br.ReadUInt32(); // reserved
 
             Blocks.Clear();
-            while (true)
+            Blocks.Capacity = (int)BlockCount;
+            for (uint b = 0; b < BlockCount; b++)
             {
-                long blockStart = br.BaseStream.Position;
                 string name = ReadCString(br);
-
-                if (name.Length == 0)
-                {
-                    // Empty name means this is the trailer's 16 zero-byte prefix, not a block.
-                    br.BaseStream.Position = blockStart + 16;
-                    ReadPropertyTrailer(br);
-                    break;
-                }
-
                 ulong count = br.ReadUInt64();
                 var block = new CrateManifestBlock { CrateName = name };
                 block.Entries.Capacity = (int)count;
@@ -119,10 +111,26 @@ namespace DieselEngineFormats.Crate
 
                 Blocks.Add(block);
             }
+
+            ReadPropertyTrailer(br);
         }
 
         private void ReadPropertyTrailer(BinaryReader br)
         {
+            // The trailer is a patch/source list followed by the property table.
+            // The list is a u64 count of records; each record is a name, three
+            // u32s, and the name repeated.
+            ulong patchCount = br.ReadUInt64();
+            for (ulong i = 0; i < patchCount; i++)
+            {
+                ReadCString(br); // patch name
+                br.ReadUInt32();
+                br.ReadUInt32();
+                br.ReadUInt32();
+                ReadCString(br); // patch name, repeated
+            }
+            br.ReadUInt64(); // reserved (0 in all known files currently)
+
             ulong count = br.ReadUInt64();
             Properties.Clear();
             Properties.Capacity = (int)count;
@@ -134,6 +142,12 @@ namespace DieselEngineFormats.Crate
                     Flag = br.ReadUInt32(),
                 });
             }
+
+            // The property table is the last thing in the file; if the record
+            // shape above is wrong we would land off the end here.
+            if (br.BaseStream.Position != br.BaseStream.Length)
+                throw new InvalidDataException(
+                    $"CrateManifest trailer parse ended at {br.BaseStream.Position}, expected EOF ({br.BaseStream.Length}).");
         }
 
         private static string ReadCString(BinaryReader br)

--- a/Crate/CrateManifest.cs
+++ b/Crate/CrateManifest.cs
@@ -28,14 +28,15 @@ namespace DieselEngineFormats.Crate
         ///     here -- the manifest doesn't list every variant. Use the .crate
         ///     TOCs as the source of truth for variants.
         /// </summary>
-        public ulong VariantFlag { get; set; }
+        public uint VariantFlag { get; set; }
 
         public CrateManifestEntry(BinaryReader br)
         {
             Extension = HashIndex.Get(br.ReadUInt64());
             Path = HashIndex.Get(br.ReadUInt64());
             Timestamp = br.ReadUInt64();
-            VariantFlag = br.ReadUInt64();
+            VariantFlag = br.ReadUInt32();
+            br.ReadUInt32(); // likely padding
         }
 
         public override string ToString() => $"{Path}.{Extension}";
@@ -82,7 +83,7 @@ namespace DieselEngineFormats.Crate
         public uint Version { get; set; }
 
         /// <summary>Number of blocks that follow the header.</summary>
-        public uint BlockCount { get; set; }
+        public ulong BlockCount { get; set; }
 
         public List<CrateManifestBlock> Blocks { get; } = new List<CrateManifestBlock>();
 
@@ -95,12 +96,11 @@ namespace DieselEngineFormats.Crate
         public override void ReadFile(BinaryReader br)
         {
             Version = br.ReadUInt32();
-            BlockCount = br.ReadUInt32();
-            br.ReadUInt32(); // reserved
+            BlockCount = br.ReadUInt64();
 
             Blocks.Clear();
             Blocks.Capacity = (int)BlockCount;
-            for (uint b = 0; b < BlockCount; b++)
+            for (ulong b = 0; b < BlockCount; b++)
             {
                 string name = ReadCString(br);
                 ulong count = br.ReadUInt64();
@@ -181,19 +181,18 @@ namespace DieselEngineFormats.Crate
             if (magic != Magic)
                 throw new InvalidDataException($"Not a crates.properties file (expected magic 0x{Magic:X8}, got 0x{magic:X8})");
 
-            uint count = br.ReadUInt32();
-            br.ReadUInt32(); // reserved
+            ulong count = br.ReadUInt64();
 
             Properties.Clear();
             Properties.Capacity = (int)count;
-            for (int i = 0; i < count; i++)
+            for (ulong i = 0; i < count; i++)
             {
                 var entry = new CratePropertyEntry
                 {
                     Name = HashIndex.Get(br.ReadUInt64()),
                     Flag = br.ReadUInt32(),
                 };
-                br.ReadUInt32(); // reserved
+                br.ReadUInt32(); // likely padding
                 Properties.Add(entry);
             }
         }

--- a/Crate/CrateManifest.cs
+++ b/Crate/CrateManifest.cs
@@ -72,7 +72,7 @@ namespace DieselEngineFormats.Crate
     ///     exist and what type they are, across every .crate file. No offsets/
     ///     sizes -- open the individual CrateFile to extract data.
     ///
-    ///     Layout: global header (12 bytes: version, block count, reserved),
+    ///     Layout: global header (12 bytes: version, 64-bit block count),
     ///     then exactly BlockCount blocks (crate name, entry count, that many
     ///     32-byte CrateManifestEntry records), then a trailer: a variable-
     ///     length patch/source list followed by the same property/bitflag table


### PR DESCRIPTION
With the PD2 open_beta update it shipped a crates_merged_patch.shipping_manifest with a new patch table to parse.

Also tightened up the block parsing to use the item count properly as the filestructure is now parsing without hacks.